### PR TITLE
Import UIKit in ChameleonStatusBar.h and NSArray+Chameleon.h

### DIFF
--- a/Chameleon/ChameleonStatusBar.h
+++ b/Chameleon/ChameleonStatusBar.h
@@ -28,6 +28,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface ChameleonStatusBar : NSObject
 

--- a/Chameleon/NSArray+Chameleon.h
+++ b/Chameleon/NSArray+Chameleon.h
@@ -28,6 +28,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import "ChameleonMacros.h"
 
 //Shade Styles Supported By Chameleon


### PR DESCRIPTION
I tried integrating Chameleon with my project running on iOS 8 with the Xcode 6 beta.
I was using Swift and encountered an error bridging Chameleon into Swift.

The Swift compiler did not recognize any of the UIKit classes in the ChamelonStatusBar class or the NSArray+Chameleon category.

I was able to fix it by importing UIKit in the headers for those classes.
After doing that I had no problems building.
