### PR TITLE
Remove cast for `calloc`

### DIFF
--- a/Pod/Classes/Objective-C/UIColor+ChameleonPrivate.m
+++ b/Pod/Classes/Objective-C/UIColor+ChameleonPrivate.m
@@ -37,7 +37,7 @@
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     
     //Extract the data we need
-    unsigned char *rawData = (unsigned char *) calloc(height * width * 4, sizeof(unsigned char));
+    unsigned char *rawData = calloc(height * width * 4, sizeof(unsigned char));
     NSUInteger bytesPerPixel = 4;
     NSUInteger bytesPerRow = bytesPerPixel * width;
     NSUInteger bitsPerComponent = 8;

--- a/Pod/Classes/Objective-C/UIImage+ChameleonPrivate.m
+++ b/Pod/Classes/Objective-C/UIImage+ChameleonPrivate.m
@@ -22,7 +22,7 @@
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     
     //Extract the data we need
-    unsigned char *rawData = (unsigned char *) calloc(height * width * 4, sizeof(unsigned char));
+    unsigned char *rawData = calloc(height * width * 4, sizeof(unsigned char));
     NSUInteger bytesPerPixel = 4;
     NSUInteger bytesPerRow = bytesPerPixel * width;
     NSUInteger bitsPerComponent = 8;


### PR DESCRIPTION
In C (and hence Objective-C) it is unnecessary to cast the result of malloc/calloc.
Reference: http://stackoverflow.com/a/605858/3181273