### PR TITLE
Remove empty class `ChameleonConstants`

### DIFF
--- a/Pod/Classes/Objective-C/ChameleonConstants.h
+++ b/Pod/Classes/Objective-C/ChameleonConstants.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 Vicc Alexander. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 /**
@@ -15,7 +14,3 @@
  *  @since 2.0
  */
 extern const UIStatusBarStyle UIStatusBarStyleContrast;
-
-@interface ChameleonConstants : NSObject
-
-@end

--- a/Pod/Classes/Objective-C/ChameleonConstants.m
+++ b/Pod/Classes/Objective-C/ChameleonConstants.m
@@ -9,7 +9,3 @@
 #import "ChameleonConstants.h"
 
 const UIStatusBarStyle UIStatusBarStyleContrast = 100;
-
-@implementation ChameleonConstants
-
-@end


### PR DESCRIPTION
`ChameleonConstants` is an empty class that is not used anywhere. 