### PR TITLE
`[UIButton font]` is deprecated

### DIFF
--- a/Pod/Classes/Objective-C/UIButton+Chameleon.m
+++ b/Pod/Classes/Objective-C/UIButton+Chameleon.m
@@ -10,14 +10,9 @@
 
 @implementation UIButton (Chameleon)
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
 - (void)setSubstituteFontName:(NSString *)name UI_APPEARANCE_SELECTOR {
     
-    self.font = [UIFont fontWithName:name size:self.font.pointSize];
+    self.titleLabel.font = [UIFont fontWithName:name size:self.titleLabel.font.pointSize];
 }
-
-#pragma GCC diagnostic pop
 
 @end


### PR DESCRIPTION
I wonder if the usage here is intentional or not, seeing the warning message being suppressed.