### PR TITLE
Add initial tvOS support to Swift pod

### DIFF
--- a/ChameleonFramework.podspec
+++ b/ChameleonFramework.podspec
@@ -26,6 +26,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Swift' do |ss|
       ss.ios.deployment_target = '8.0'
+      ss.tvos.deployment_target = '9.0'
       ss.source_files = 'Pod/Classes/Swift/ChameleonShorthand.swift'
       ss.dependency 'ChameleonFramework/Default'
   end

--- a/Pod/Classes/Objective-C/Chameleon.h
+++ b/Pod/Classes/Objective-C/Chameleon.h
@@ -18,7 +18,9 @@ FOUNDATION_EXPORT const unsigned char ChameleonVersionString[];
 
 #import "Chameleon_.h"
 
+#if TARGET_OS_IOS
 #import "UIButton+Chameleon.h"
+#endif
 #import "UILabel+Chameleon.h"
 #import "UIColor+ChameleonPrivate.h"
 #import "UIImage+ChameleonPrivate.h"


### PR DESCRIPTION
- Add tvOS deployment target to the Swift subspec.
- Avoid importing `UIButton+Chameleon.h` in non-iOS targets since it is not available on tvOS.