### PR TITLE
muted error  when building via carthage v0.18 in swift 3

### DIFF
--- a/Pod/Classes/Objective-C/UIView+ChameleonPrivate.m
+++ b/Pod/Classes/Objective-C/UIView+ChameleonPrivate.m
@@ -20,9 +20,9 @@
                                             CGRectGetMidY(self.bounds));
     
     CGPoint centerPointOfSelfInWindow = [self convertPoint:centerPointInSelf
-                                                    toView:self.window];
+                                                    toView:(UIView *)self.window];
     
-    UIView *view = [self.window findTopMostViewForPoint:centerPointOfSelfInWindow];
+    UIView *view = [(UIView *)self.window findTopMostViewForPoint:centerPointOfSelfInWindow];
     BOOL isTopMost = view == self || [view isDescendantOfView:self];
     
     return isTopMost;


### PR DESCRIPTION
muted error `UIView+ChameleonPrivate.m:25:21: error: receiver type 'UIWindow' for instance message is a forward declaration` when building via carthage v0.18 in swift 3