### PR TITLE
Added whitespace elimination before parsing hexString

### DIFF
--- a/Pod/Classes/Objective-C/UIColor+Chameleon.m
+++ b/Pod/Classes/Objective-C/UIColor+Chameleon.m
@@ -571,6 +571,9 @@
         return nil;
     }
     
+    //Eliminate any whitespace before proceding
+    string = [string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    
     //Check to see if we need to add a hashtag
     if('#' != [string characterAtIndex:0]) {
         string = [NSString stringWithFormat:@"#%@", string];


### PR DESCRIPTION
Since colorWithHexString did not handle the potential presence of white-spaces in the hexString passed, any string with a leading or trailing whitespace would fail parsing.  