### PR TITLE
New SplitComplementary Color Schemes

### DIFF
--- a/Pod/Classes/Objective-C/NSArray+Chameleon.h
+++ b/Pod/Classes/Objective-C/NSArray+Chameleon.h
@@ -55,7 +55,11 @@ typedef NS_ENUM(NSInteger, ColorScheme){
      *
      *  @since 1.0
      */
-    ColorSchemeComplementary
+    ColorSchemeComplementary,
+    /**
+     *  Rather than the point opposite the key color on the wheel, the split complementary takes the two colors directly on either side of the complementary color. This allows for a nicer range of colors while still not deviating from the basic harmony between the key color and the complementary color.
+     */
+    ColorSchemeSplitComplementary
 };
 
 @interface NSArray (Chameleon)

--- a/Pod/Classes/Objective-C/NSArray+Chameleon.m
+++ b/Pod/Classes/Objective-C/NSArray+Chameleon.m
@@ -64,6 +64,8 @@
             return [self complementaryColorSchemeFromHue:h Saturation:s Brightness:b flat:isFlatScheme];
         case ColorSchemeTriadic:
             return [self triadicColorSchemeFromHue:h Saturation:s Brightness:b flat:isFlatScheme];
+        case ColorSchemeSplitComplementary:
+            return [self splitComplementaryColorSchemeFromHue:h Saturation:s Brightness:b flat:isFlatScheme];
         default:
             NSAssert(0, @"Oops! Unrecognized color scheme provided as random color.");
     }
@@ -93,6 +95,9 @@
         case ColorSchemeTriadic:
             if (isFlatScheme) return [self triadicColorSchemeFromHue:h Saturation:s Brightness:b flat:YES];
             else return [self triadicColorSchemeFromHue:h Saturation:s Brightness:b flat:NO];
+        case ColorSchemeSplitComplementary:
+            if (isFlatScheme) return [self splitComplementaryColorSchemeFromHue:h Saturation:s Brightness:b flat:YES];
+            else return [self splitComplementaryColorSchemeFromHue:h Saturation:s Brightness:b flat:NO];
             default:
             NSAssert(0, @"Oops! Unrecognized color scheme provided as random color.");
     }
@@ -543,6 +548,79 @@
     
     return @[firstColor, secondColor, thirdColor, fourthColor, fifthColor];
 }
+
+// Creates an array of 5 colors, both 150 degrees and 210 degrees away from the predefined colors on both sides which is basically 30 away from both side of a predefined color's complementary
++ (NSArray *)splitComplementaryColorSchemeFromHue:(CGFloat)h Saturation:(CGFloat)s Brightness:(CGFloat)b flat:(BOOL)isFlat  {
+    
+    UIColor *firstColor = [UIColor colorWithHue:[[self class] add:150 to:h]/360
+                                     saturation:(7*s/6)/100
+                                     brightness:(b-5)/100
+                                          alpha:1.0];
+    
+    UIColor *secondColor = [UIColor colorWithHue:[[self class] add:150 to:h]/360
+                                      saturation:s/100
+                                      brightness:(b+9)/100
+                                           alpha:1.0];
+    
+    UIColor *thirdColor = [UIColor colorWithHue:h/360
+                                     saturation:s/100
+                                     brightness:b/100
+                                          alpha:1.0];
+    
+    UIColor *fourthColor = [UIColor colorWithHue:[[self class] add:210 to:h]/360
+                                      saturation:(7*s/6)/100
+                                      brightness:(b-5)/100
+                                           alpha:1.0];
+    
+    UIColor *fifthColor = [UIColor colorWithHue:[[self class] add:210 to:h]/360
+                                     saturation:s/100
+                                     brightness:(b-30)/100
+                                          alpha:1.0];
+    
+    if (isFlat) {
+        
+        //Flatten colors
+        firstColor = [firstColor flatten];
+        secondColor = [secondColor flatten];
+        thirdColor = [thirdColor flatten];
+        fourthColor = [fourthColor flatten];
+        fifthColor = [fifthColor flatten];
+        
+        //Make sure returned colors are unique
+        
+        //Inner Colors
+        if ([secondColor isEqual:thirdColor]) {
+            secondColor = [[secondColor darkenByPercentage:0.25] flatten];
+        }
+        
+        if ([thirdColor isEqual:fourthColor]) {
+            fourthColor = [[fourthColor darkenByPercentage:0.25] flatten];
+        }
+        
+        if ([firstColor isEqual:thirdColor]) {
+            firstColor = [[firstColor darkenByPercentage:0.25] flatten];
+        }
+        
+        if ([fifthColor isEqual:thirdColor]) {
+            fifthColor = [[fifthColor darkenByPercentage:0.25] flatten];
+        }
+        
+        //Outer Colors
+        
+        if ([firstColor isEqual:secondColor]) {
+            firstColor = [[firstColor darkenByPercentage:0.25] flatten];
+        }
+        
+        
+        if ([fourthColor isEqual:fifthColor]) {
+            fifthColor = [[fifthColor darkenByPercentage:0.25] flatten];
+        }
+        
+    }
+    
+    return @[firstColor, secondColor, thirdColor, fourthColor, fifthColor];
+}
+
 
 #pragma mark - Helper Methods for Color Schemes
 


### PR DESCRIPTION
New Split Complementary color scheme.

It returns an array of the Analogous Colors of a given color's Complementary Color. Ex:
![color-wheel-split-250x250](https://cloud.githubusercontent.com/assets/4937515/24082650/31cf1856-0d04-11e7-9295-6de34484b3b0.png)

The resulting colors are similar to Triadic, only the colors are closer to each other. Ex:
Triad Color Scheme for light Teal
![triadteal](https://cloud.githubusercontent.com/assets/4937515/24082703/e0acb572-0d04-11e7-95a9-dc1a13727966.png)

Split Complementary Scheme for light Teal
![splitteal](https://cloud.githubusercontent.com/assets/4937515/24082704/eaece43a-0d04-11e7-8421-f1f76f58efed.png)

Triad Color Scheme for Pink
![triadpink](https://cloud.githubusercontent.com/assets/4937515/24082723/215112e4-0d05-11e7-8d52-2dd9ae5c3b4f.png)

Split Complementary for Pink
![splitpink](https://cloud.githubusercontent.com/assets/4937515/24082727/2ecbae48-0d05-11e7-9292-9084cc801b4d.png)




