### PR TITLE
Fixed "Documentation issue" warning in Xcode 8

### DIFF
--- a/Pod/Classes/Objective-C/UIColor+Chameleon.h
+++ b/Pod/Classes/Objective-C/UIColor+Chameleon.h
@@ -813,7 +813,7 @@ typedef NS_ENUM (NSInteger, UIShadeStyle) {
  *
  *  Returns a randomly generated flat color object NOT found in the specified array.
  *
- *  @param excludedColors An array specifying which colors NOT to return.
+ *  @param colors An array specifying which colors NOT to return.
  *
  *  @return A flat @c UIColor object in the HSB colorspace.
  *
@@ -914,8 +914,8 @@ typedef NS_ENUM (NSInteger, UIShadeStyle) {
 /**
  *  Creates and returns either a black or white color object depending on which contrasts more with a specified color.
  *
- *  @param color The specified color of the contrast color that is being requested.
- *  @param isFlat Pass YES to return flat color objects.
+ *  @param backgroundColor The specified color of the contrast color that is being requested.
+ *  @param flat Pass YES to return flat color objects.
  *
  *  @return A UIColor object in the HSB colorspace.
  *
@@ -927,8 +927,8 @@ typedef NS_ENUM (NSInteger, UIShadeStyle) {
 /**
  *  Creates and returns either a black or white color object depending on which contrasts more with a specified color.
  *
- *  @param color The specified color of the contrast color that is being requested.
- *  @param isFlat Pass YES to return flat color objects.
+ *  @param backgroundColor The specified color of the contrast color that is being requested.
+ *  @param flat Pass YES to return flat color objects.
  *  @param alpha The opacity.
  *
  *  @return A UIColor object in the HSB colorspace.


### PR DESCRIPTION
Fixed a documentation comment that triggered a warning in Xcode 8 when using Chameleon as a module (use_frameworks! in Cocoapods)