### PR TITLE
Change +load methods to static __attribute__((constructor)) functions

### DIFF
--- a/Pod/Classes/Objective-C/UINavigationController+Chameleon.m
+++ b/Pod/Classes/Objective-C/UINavigationController+Chameleon.m
@@ -30,12 +30,11 @@
 
 #pragma mark - Swizzling
 
-+ (void)load {
-    
+__attribute__((constructor)) static void chameleon_swizzleUINavigationController(void) {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         
-        Class class = [self class];
+        Class class = [UINavigationController class];
         
         SEL originalSelector = @selector(viewDidLoad);
         SEL swizzledSelector = @selector(chameleon_viewDidLoad);

--- a/Pod/Classes/Objective-C/UIViewController+Chameleon.m
+++ b/Pod/Classes/Objective-C/UIViewController+Chameleon.m
@@ -62,12 +62,11 @@
 
 #pragma mark - Swizzling
 
-+ (void)load {
-    
+__attribute__((constructor)) static void chameleon_swizzleUIViewController(void) {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         
-        Class class = [self class];
+        Class class = [UIViewController class];
         
         SEL originalSelector = @selector(preferredStatusBarStyle);
         SEL swizzledSelector = @selector(chameleon_preferredStatusBarStyle);


### PR DESCRIPTION
With the latest version of Xcode installed I was getting this dyld error at app launch time:

```Swift class extensions and categories on Swift classes are not allowed to have +load methods```

It looks like it's possible to replace `+load` methods with a static `__attribute__((constructor))` function without making dyld angry.